### PR TITLE
added an option 'ignoreDeleted' for ingnoring  scripts in deleted state.

### DIFF
--- a/dbmaintain/src/main/java/org/dbmaintain/DbMaintainerFactory.java
+++ b/dbmaintain/src/main/java/org/dbmaintain/DbMaintainerFactory.java
@@ -45,6 +45,7 @@ public class DbMaintainerFactory extends FactoryWithDatabase<DbMaintainer> {
         boolean allowOutOfSequenceExecutionOfPatchScripts = PropertyUtils.getBoolean(PROPERTY_PATCH_ALLOWOUTOFSEQUENCEEXECUTION, getConfiguration());
         boolean disableConstraintsEnabled = PropertyUtils.getBoolean(PROPERTY_DISABLE_CONSTRAINTS, getConfiguration());
         boolean updateSequencesEnabled = PropertyUtils.getBoolean(PROPERTY_UPDATE_SEQUENCES, getConfiguration());
+        boolean ignoreDeletions = PropertyUtils.getBoolean(PROPERTY_IGNORE_DELETIONS, false, getConfiguration());        
         long maxNrOfCharsWhenLoggingScriptContent = PropertyUtils.getLong(PROPERTY_MAX_NR_CHARS_WHEN_LOGGING_SCRIPT_CONTENT, getConfiguration());
         ScriptIndexes baseLineRevision = factoryWithDatabaseContext.getBaselineRevision();
 
@@ -56,11 +57,10 @@ public class DbMaintainerFactory extends FactoryWithDatabase<DbMaintainer> {
         ScriptRunner scriptRunner = mainFactory.createScriptRunner();
         ScriptUpdatesFormatter scriptUpdatesFormatter = createScriptUpdatesFormatter();
         ExecutedScriptInfoSource executedScriptInfoSource = mainFactory.createExecutedScriptInfoSource();
-
-
-        return new DefaultDbMaintainer(scriptRunner, scriptRepository, executedScriptInfoSource, fromScratchEnabled, useScriptFileLastModificationDates,
-                allowOutOfSequenceExecutionOfPatchScripts, cleanDbEnabled, disableConstraintsEnabled, updateSequencesEnabled, dbClearer, dbCleaner,
-                constraintsDisabler, sequenceUpdater, scriptUpdatesFormatter, getSqlHandler(), maxNrOfCharsWhenLoggingScriptContent, baseLineRevision);
+        return new DefaultDbMaintainer(scriptRunner, scriptRepository, executedScriptInfoSource, fromScratchEnabled,
+                useScriptFileLastModificationDates, allowOutOfSequenceExecutionOfPatchScripts, cleanDbEnabled, disableConstraintsEnabled,
+                updateSequencesEnabled, dbClearer, dbCleaner, constraintsDisabler, sequenceUpdater, scriptUpdatesFormatter,
+                getSqlHandler(), maxNrOfCharsWhenLoggingScriptContent, baseLineRevision, ignoreDeletions);
     }
 
 

--- a/dbmaintain/src/main/java/org/dbmaintain/config/DbMaintainProperties.java
+++ b/dbmaintain/src/main/java/org/dbmaintain/config/DbMaintainProperties.java
@@ -247,6 +247,8 @@ public class DbMaintainProperties {
 
     public static final String PROPERTY_SCRIPT_PARAMETER_FILE = "dbMaintainer.scriptParameterFile";
 
+    public static final String PROPERTY_IGNORE_DELETIONS = "dbMaintainer.ignoreDeletions";
+
     /**
      * Private constructor to prevent instantiation
      */

--- a/dbmaintain/src/main/java/org/dbmaintain/script/analyzer/ScriptUpdates.java
+++ b/dbmaintain/src/main/java/org/dbmaintain/script/analyzer/ScriptUpdates.java
@@ -17,6 +17,8 @@ package org.dbmaintain.script.analyzer;
 
 import java.util.SortedSet;
 
+import org.dbmaintain.script.Script;
+
 import static org.dbmaintain.util.CollectionUtils.unionSortedSet;
 
 /**
@@ -32,16 +34,19 @@ public class ScriptUpdates {
     private SortedSet<ScriptUpdate> regularlyAddedPatchScripts;
     private SortedSet<ScriptUpdate> regularPostprocessingScriptUpdates;
     private SortedSet<ScriptUpdate> regularlyRenamedScripts;
+    private SortedSet<ScriptUpdate> ignoredScripts;
 
     protected ScriptUpdates(SortedSet<ScriptUpdate> regularlyAddedOrModifiedScripts, SortedSet<ScriptUpdate> irregularScriptUpdates,
                             SortedSet<ScriptUpdate> regularlyDeletedRepeatableScripts, SortedSet<ScriptUpdate> regularlyAddedPatchScripts,
-                            SortedSet<ScriptUpdate> regularPostprocessingScriptUpdates, SortedSet<ScriptUpdate> regularlyRenamedScripts) {
+                            SortedSet<ScriptUpdate> regularPostprocessingScriptUpdates, SortedSet<ScriptUpdate> regularlyRenamedScripts,
+                            SortedSet<ScriptUpdate> ignoredScripts) {
         this.regularlyAddedOrModifiedScripts = regularlyAddedOrModifiedScripts;
         this.irregularScriptUpdates = irregularScriptUpdates;
         this.regularlyDeletedRepeatableScripts = regularlyDeletedRepeatableScripts;
         this.regularlyAddedPatchScripts = regularlyAddedPatchScripts;
         this.regularPostprocessingScriptUpdates = regularPostprocessingScriptUpdates;
         this.regularlyRenamedScripts = regularlyRenamedScripts;
+        this.ignoredScripts = ignoredScripts;
     }
 
 
@@ -49,6 +54,9 @@ public class ScriptUpdates {
         return regularlyAddedOrModifiedScripts;
     }
 
+    public SortedSet<ScriptUpdate> getIgnoredScripts() {
+        return ignoredScripts;
+    }
 
     public SortedSet<ScriptUpdate> getIrregularScriptUpdates() {
         return irregularScriptUpdates;
@@ -85,6 +93,13 @@ public class ScriptUpdates {
         return irregularScriptUpdates.size() > 0;
     }
 
+    public boolean hasIgnoredScripts() {
+        return ignoredScripts.size() > 0;
+    }
+
+    public boolean hasIgnoredScriptsAndScriptChanges() {
+        return hasIgnoredScripts() && getRegularScriptUpdates().size() > 0;
+    }
 
     public boolean noUpdatesOtherThanRepeatableScriptDeletionsOrRenames() {
         return regularlyAddedOrModifiedScripts.size() == 0 && irregularScriptUpdates.size() == 0 &&

--- a/dbmaintain/src/test/java/org/dbmaintain/DefaultDbMaintainerScriptErrorTest.java
+++ b/dbmaintain/src/test/java/org/dbmaintain/DefaultDbMaintainerScriptErrorTest.java
@@ -93,7 +93,8 @@ public class DefaultDbMaintainerScriptErrorTest extends UnitilsJUnit4 {
 
 
     private DefaultDbMaintainer createDefaultDbMaintainer(long maxNrOfCharsWhenLoggingScriptContent) {
-        return new DefaultDbMaintainer(scriptRunner.getMock(), null, executedScriptInfoSource.getMock(), false, false, false, false, false, false, null, null, null, null, null, null, maxNrOfCharsWhenLoggingScriptContent, null);
+        return new DefaultDbMaintainer(scriptRunner.getMock(), null, executedScriptInfoSource.getMock(), false, false, false, false, false,
+                false, null, null, null, null, null, null, maxNrOfCharsWhenLoggingScriptContent, null, false);
     }
 
 }


### PR DESCRIPTION
This option is needed if you want to ensure that the database has at least
a given version.
Please push the change into the red6/dbmaintain repo. 
